### PR TITLE
Add detection of missing entity lazy fetching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,41 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.3] - 2020-05-10
+### Added
+- Add back a more specific detection of N+1 queries due to missing lazy fetching.
+
+### Changed
+- Make the detection of N+1 queries due to missing eager fetching on the queries more specific.
+
+## [1.0.2] - 2020-05-08
+### Changed
+- Rename N+1 query to plural.
+
+### Removed
+- [BUG FIX] Temporarily remove detection of eager fetching on queries to avoid false positives.
+
+## [1.0.1] - 2015-05-06
+### Changed
+- [BUG FIX] Fix initialisation of ThreadLocal variables to avoid NullPointerExceptions.
+
+## [1.0.0] - 2020-05-01
+### Added
+- Auto detection of N+1  queries
+- Error level configuration by application properties
+
+## [0.1.0] - 2019-12-18
+### Added
+- Feature to count the queries
+
+[Unreleased]: https://github.com/yannbriancon/spring-hibernate-query-utils/compare/v1.0.3...HEAD
+[1.0.3]: https://github.com/yannbriancon/spring-hibernate-query-utils/compare/v1.0.2...v1.0.3
+[1.0.2]: https://github.com/yannbriancon/spring-hibernate-query-utils/compare/v1.0.1...v1.0.2
+[1.0.1]: https://github.com/yannbriancon/spring-hibernate-query-utils/compare/v1.0.0...v1.0.1
+[1.0.0]: https://github.com/yannbriancon/spring-hibernate-query-utils/compare/v0.1.0...v1.0.0
+[0.1.0]: https://github.com/yannbriancon/spring-hibernate-query-utils/tree/v0.1.0

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Add the dependency to your project inside your `pom.xml` file
 <dependency>
     <groupId>com.yannbriancon</groupId>
     <artifactId>spring-hibernate-query-utils</artifactId>
-    <version>1.0.2</version>
+    <version>1.0.3</version>
 </dependency>
 ```
 

--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@
     Spring Hibernate Query Utils: an easy way of detecting N+1 queries and counting queries in a Spring/Hibernate application 
     <br />
     <br />
-    <a href="https://github.com/yannbriancon/spring-hibernate-query-count/issues">Report Bug</a>
+    <a href="https://github.com/yannbriancon/spring-hibernate-query-utils/issues">Report Bug</a>
     ·
-    <a href="https://github.com/yannbriancon/spring-hibernate-query-count/issues">Request Feature</a>
+    <a href="https://github.com/yannbriancon/spring-hibernate-query-utils/issues">Request Feature</a>
   </p>
 </p>
 
@@ -45,6 +45,7 @@
     * [Detection](#detection)
     * [Configuration](#configuration)
   * [Query Count](#query-count)
+* [Changelog](#changelog)
 * [License](#license)
 * [Contact](#contact)
 
@@ -102,7 +103,13 @@ The N+1 queries detection is enabled by default so no configuration is needed.
 
 Each time N+1 queries are detected in a transaction, a log of level error will be sent.
 
-Here is an example catching the N+1 queries detection error log:
+Two types of N+1 queries are detected:
+
+- N+1 queries caused by a field needed but not eager fetched on a specific query
+
+- N+1 queries caused by an entity field not configured to be fetched lazily
+
+Here is an example catching the error log for the first type of N+1 queries:
 
 ```java
 @RunWith(MockitoJUnitRunner.class)
@@ -225,6 +232,10 @@ public class NotificationResourceIntTest {
 }
 ```
 
+<!-- CHANGELOG -->
+## Changelog
+
+See [`CHANGELOG`][changelog-url] for more information.
 
 
 <!-- LICENSE -->
@@ -239,18 +250,19 @@ Distributed under the MIT License. See [`LICENSE`][license-url] for more informa
 
 [@YBriancon](https://twitter.com/YBriancon) - yann.briancon.73@gmail.com
 
-Project Link: [https://github.com/yannbriancon/spring-hibernate-query-count](https://github.com/yannbriancon/spring-hibernate-query-count)
+Project Link: [https://github.com/yannbriancon/spring-hibernate-query-utils](https://github.com/yannbriancon/spring-hibernate-query-utils)
 
 
 <!-- MARKDOWN LINKS & IMAGES -->
 <!-- https://www.markdownguide.org/basic-syntax/#reference-style-links -->
-[contributors-shield]: https://img.shields.io/github/contributors/yannbriancon/spring-hibernate-query-count.svg?style=flat-square
-[contributors-url]: https://github.com/yannbriancon/spring-hibernate-query-count/graphs/contributors
-[forks-shield]: https://img.shields.io/github/forks/yannbriancon/spring-hibernate-query-count.svg?style=flat-square
-[forks-url]: https://github.com/yannbriancon/spring-hibernate-query-count/network/members
-[stars-shield]: https://img.shields.io/github/stars/yannbriancon/spring-hibernate-query-count.svg?style=flat-square
-[stars-url]: https://github.com/yannbriancon/spring-hibernate-query-count/stargazers
-[issues-shield]: https://img.shields.io/github/issues/yannbriancon/spring-hibernate-query-count.svg?style=flat-square
-[issues-url]: https://github.com/yannbriancon/spring-hibernate-query-count/issues
-[license-shield]: https://img.shields.io/github/license/yannbriancon/spring-hibernate-query-count.svg?style=flat-square
-[license-url]: https://github.com/yannbriancon/spring-hibernate-query-count/blob/master/LICENSE
+[contributors-shield]: https://img.shields.io/github/contributors/yannbriancon/spring-hibernate-query-utils.svg?style=flat-square
+[contributors-url]: https://github.com/yannbriancon/spring-hibernate-query-utils/graphs/contributors
+[forks-shield]: https://img.shields.io/github/forks/yannbriancon/spring-hibernate-query-utils.svg?style=flat-square
+[forks-url]: https://github.com/yannbriancon/spring-hibernate-query-utils/network/members
+[stars-shield]: https://img.shields.io/github/stars/yannbriancon/spring-hibernate-query-utils.svg?style=flat-square
+[stars-url]: https://github.com/yannbriancon/spring-hibernate-query-utils/stargazers
+[issues-shield]: https://img.shields.io/github/issues/yannbriancon/spring-hibernate-query-utils.svg?style=flat-square
+[issues-url]: https://github.com/yannbriancon/spring-hibernate-query-utils/issues
+[license-shield]: https://img.shields.io/github/license/yannbriancon/spring-hibernate-query-utils.svg?style=flat-square
+[license-url]: https://github.com/yannbriancon/spring-hibernate-query-utils/blob/master/LICENSE
+[changelog-url]: https://github.com/yannbriancon/spring-hibernate-query-utils/blob/master/CHANGELOG

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ class NPlusOneQueriesLoggingTest {
     }
 
     @Test
-    void nPlusOneQueriesDetection_isLoggingWhenDetectingNPlusOneQueries() {
+    void hibernateQueryInterceptor_isDetectingNPlusOneQueriesWhenMissingEagerFetchingOnQuery() {
         // Fetch the 2 messages without the authors
         List<Message> messages = messageRepository.findAll();
 
@@ -141,9 +141,9 @@ class NPlusOneQueriesLoggingTest {
         assertThat(loggingEvent.getMessage())
                 .isEqualTo("N+1 queries detected on a getter of the entity com.yannbriancon.utils.entity.User\n" +
                         "    at com.yannbriancon.interceptor.NPlusOneQueriesLoggingTest." +
-                        "lambda$nPlusOneQueriesDetection_isLoggingWhenDetectingNPlusOneQueries$0" +
-                        "(NPlusOneQueriesLoggingTest.java:56)\n" +
-                        "    Hint: Missing Eager fetching configuration on the query that fetches the object of type" +
+                        "lambda$hibernateQueryInterceptor_isDetectingNPlusOneQueriesWhenMissingEagerFetchingOnQuery$0" +
+                        "(NPlusOneQueriesLoggingTest.java:61)\n" +
+                        "    Hint: Missing Eager fetching configuration on the query that fetched the object of type" +
                         " com.yannbriancon.utils.entity.User\n");
         assertThat(Level.ERROR).isEqualTo(loggingEvent.getLevel());
     }

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.yannbriancon</groupId>
     <artifactId>spring-hibernate-query-utils</artifactId>
-    <version>1.0.2</version>
+    <version>1.0.3</version>
     <packaging>jar</packaging>
 
     <name>spring-hibernate-query-utils</name>

--- a/src/main/java/com/yannbriancon/interceptor/HibernateQueryInterceptor.java
+++ b/src/main/java/com/yannbriancon/interceptor/HibernateQueryInterceptor.java
@@ -147,6 +147,26 @@ public class HibernateQueryInterceptor extends EmptyInterceptor {
         return true;
     }
 
+
+    /**
+     * Get the Proxy method name that was called first to know which query triggered the interceptor
+     *
+     * @return Optional of method name if found
+     */
+    private Optional<String> getProxyMethodName() {
+        StackTraceElement[] stackTraceElements = Thread.currentThread().getStackTrace();
+
+        for (int i = stackTraceElements.length - 1; i >= 0; i--) {
+            StackTraceElement stackTraceElement = stackTraceElements[i];
+
+            if (stackTraceElement.getClassName().indexOf("com.sun.proxy") == 0) {
+                return Optional.of(stackTraceElement.getClassName() + stackTraceElement.getMethodName());
+            }
+        }
+
+        return Optional.empty();
+    }
+
     /**
      * Log the detected N+1 queries error message or throw an exception depending on the configured error level
      *

--- a/src/test/java/com/yannbriancon/interceptor/NPlusOneQueriesExceptionTest.java
+++ b/src/test/java/com/yannbriancon/interceptor/NPlusOneQueriesExceptionTest.java
@@ -41,7 +41,7 @@ class NPlusOneQueriesExceptionTest {
                             ".lambda$nPlusOneQueriesDetection_throwCallbackExceptionWhenNPlusOneQueries$0" +
                             "(NPlusOneQueriesExceptionTest.java:34)\n" +
                             "    Hint: Missing Eager fetching configuration on the query " +
-                            "that fetches the object of type com.yannbriancon.utils.entity.User\n");
+                            "that fetched the object of type com.yannbriancon.utils.entity.User\n");
         }
     }
 

--- a/src/test/java/com/yannbriancon/utils/entity/Post.java
+++ b/src/test/java/com/yannbriancon/utils/entity/Post.java
@@ -1,0 +1,41 @@
+package com.yannbriancon.utils.entity;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+
+@Entity
+@Table(name = "posts")
+public class Post {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "message_id")
+    private Message message;
+
+    public Post() {
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Message getMessage() {
+        return message;
+    }
+
+    public void setMessage(Message message) {
+        this.message = message;
+    }
+}

--- a/src/test/java/com/yannbriancon/utils/repository/PostRepository.java
+++ b/src/test/java/com/yannbriancon/utils/repository/PostRepository.java
@@ -1,0 +1,9 @@
+package com.yannbriancon.utils.repository;
+
+import com.yannbriancon.utils.entity.Post;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Component;
+
+@Component
+public interface PostRepository extends JpaRepository<Post, Long> {
+}

--- a/src/test/resources/import.sql
+++ b/src/test/resources/import.sql
@@ -5,3 +5,7 @@ VALUES (1, 'name'),
 INSERT INTO messages(id, text, author_id)
 VALUES (1, 'small desc', 1),
        (2, 'long desc', 2);
+
+INSERT INTO posts(id, message_id)
+VALUES (1, 1),
+       (2, 2);


### PR DESCRIPTION
### Added
- Add back a more specific detection of N+1 queries due to missing lazy fetching.
- Add changelog

### Changed
- Make the detection of N+1 queries due to missing eager fetching on the queries more specific.

Bump version to 1.0.3