### PR TITLE
Correct declared dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,18 +48,36 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-core</artifactId>
+            <exclusions>
+                <exclusion>
+                    <artifactId>javax.activation-api</artifactId>
+                    <groupId>javax.activation</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-data-jpa</artifactId>
+            <artifactId>spring-boot</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-autoconfigure</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
         </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-configuration-processor</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-validation</artifactId>
+            <optional>true</optional>
         </dependency>
 
         <dependency>
@@ -67,10 +85,19 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
-
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.data</groupId>
+            <artifactId>spring-data-jpa</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.data</groupId>
+            <artifactId>spring-data-commons</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/com/yannbriancon/interceptor/HibernateQueryInterceptor.java
+++ b/src/main/java/com/yannbriancon/interceptor/HibernateQueryInterceptor.java
@@ -11,11 +11,7 @@ import org.springframework.stereotype.Component;
 
 import javax.persistence.EntityManager;
 import java.io.Serializable;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import java.util.function.Supplier;
 
 @Component
@@ -57,6 +53,8 @@ public class HibernateQueryInterceptor extends EmptyInterceptor {
      * Clearing the Hibernate Session is necessary to detect N+1 queries in tests as they would be in production.
      * Otherwise, every objects created in the setup of the tests would already be loaded in the Session and would
      * hide potential N+1 queries.
+     *
+     * @param entityManager EntityManager for the session
      */
     public void clearNPlusOneQuerySession(EntityManager entityManager) {
         entityManager.clear();
@@ -72,6 +70,8 @@ public class HibernateQueryInterceptor extends EmptyInterceptor {
 
     /**
      * Get the query count for the considered thread
+     *
+     * @return The query count
      */
     public Long getQueryCount() {
         return threadQueryCount.get();


### PR DESCRIPTION
As spring-hibernate-query-utils is included as library in other projects it should only declare transitive dependencies it really needs.

I cleaned up your dependency section, removed starters from compile scope. moved a lot to the test scope and declared the annotation processor as optional.