### PR TITLE
Resolves #26 Added HibernateQueryOnRequestResetInterceptor

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,19 @@ public class NotificationResourceIntTest {
 }
 ```
 
+### Reset Query Detection State on each Request
+SpringBoot/Tomcat is reusing executer threads. This can lead to wrong N+1 detection due to old queries in ThreadLocal.
+Register following interceptor in you WebMvcConfigurer:
+
+```java
+@Override
+public void addInterceptors(InterceptorRegistry registry) {
+    registry.addInterceptor(applicationContext.getBean(HibernateQueryOnRequestResetInterceptor.class));
+}
+```
+
+
+
 <!-- CHANGELOG -->
 ## Changelog
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.yannbriancon</groupId>
     <artifactId>spring-hibernate-query-utils</artifactId>
-    <version>2.0.0</version>
+    <version>2.1.0</version>
     <packaging>jar</packaging>
 
     <name>spring-hibernate-query-utils</name>
@@ -56,6 +56,11 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-configuration-processor</artifactId>
         </dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/src/main/java/com/yannbriancon/interceptor/HibernateQueryInterceptor.java
+++ b/src/main/java/com/yannbriancon/interceptor/HibernateQueryInterceptor.java
@@ -46,7 +46,7 @@ public class HibernateQueryInterceptor extends EmptyInterceptor {
     /**
      * Reset the N+1 query detection state
      */
-    private void resetNPlusOneQueryDetectionState() {
+    public void resetNPlusOneQueryDetectionState() {
         threadPreviouslyLoadedEntities.set(new HashSet<>());
         threadSelectQueriesInfoPerProxyMethod.set(new HashMap<>());
     }

--- a/src/main/java/com/yannbriancon/interceptor/HibernateQueryOnRequestResetInterceptor.java
+++ b/src/main/java/com/yannbriancon/interceptor/HibernateQueryOnRequestResetInterceptor.java
@@ -1,0 +1,25 @@
+package com.yannbriancon.interceptor;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@Component
+@ComponentScan(basePackages = {"com.yannbriancon"})
+public class HibernateQueryOnRequestResetInterceptor implements HandlerInterceptor {
+
+	@Autowired
+	HibernateQueryInterceptor hibernateQueryInterceptor;
+
+	@Override
+	public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+
+		// Reset query detection state on each new request
+		hibernateQueryInterceptor.resetNPlusOneQueryDetectionState();
+		return true;
+	}
+}


### PR DESCRIPTION
Resolves #26 Added HibernateQueryOnRequestResetInterceptor which can be used to reset query detection state on each request